### PR TITLE
Corrected wrong Birth Dates from API, Added awardedmatches to the computation of the standings

### DIFF
--- a/sports-db-project/sports_db_dbt/dbt_project.yml
+++ b/sports-db-project/sports_db_dbt/dbt_project.yml
@@ -98,3 +98,4 @@ vars:
   max_number_of_matches: 46 # The highest number of matches played in a season per team is 46, in Championship
   max_number_of_pts: 138 # 3 pts*max_number_of_matches
   max_number_of_teams: 24 # Championship has the most teams
+  default_birth_date: CAST('1995-01-01' AS DATE) # In some occasions, API is wrong on birhtdates and the player's birthdate cannot be retrieved. In this case, we add a default birth date

--- a/sports-db-project/sports_db_dbt/models/marts/mart_football/football_football_data__standings_current.sql
+++ b/sports-db-project/sports_db_dbt/models/marts/mart_football/football_football_data__standings_current.sql
@@ -33,8 +33,9 @@ matches_with_pts AS (
 		END AS away_team_pts,
 		*
 	FROM matches
-    WHERE status = 'finished' AND stage IN ('regular season', 'league stage') -- Don't account for playoffs (for instance in CL)
-),
+    WHERE status IN ('finished', 'awarded') AND stage NOT IN ('playoffs') -- Don't account for playoffs (for instance in CL)
+	-- Note that the 'awarded' status corresponds to a decision extern to the match setting the result. Let's say your fans burned the stadium, a commission could decide to award a 2-0 win to your opponent. 
+),	
 
 home_matches AS (
 	SELECT

--- a/sports-db-project/sports_db_dbt/models/marts/mart_football/football_football_data__standings_versions.sql
+++ b/sports-db-project/sports_db_dbt/models/marts/mart_football/football_football_data__standings_versions.sql
@@ -44,7 +44,7 @@ matches_per_team_with_matches_info AS (
 		END AS match_team_pts, -- The number of points won during a match
 	FROM matches_per_team
 	LEFT JOIN matches USING (match_id)
-	WHERE status = 'finished'
+	WHERE status IN ('finished', 'awarded') 
 	ORDER BY match_start_at
 ),
 

--- a/sports-db-project/sports_db_dbt/models/staging/stg_football_data__matches.yml
+++ b/sports-db-project/sports_db_dbt/models/staging/stg_football_data__matches.yml
@@ -61,7 +61,7 @@ models:
         data_type: VARCHAR
         data_tests:
           - not_null:
-              where: status = 'finished'
+              where: status IN ('finished', 'awarded')
           - accepted_values:
               values: ['home', 'away', 'draw']
       - name: duration_type
@@ -140,9 +140,9 @@ models:
         expression: match_at > CAST('2020-01-01T00:00:00' AS TIMESTAMP) # Just to spot weird dates
     - dbt_utils.expression_is_true:
         expression: match_at < last_updated_at
-        where: status = 'finished'
+        where: status IN ('finished', 'awarded')
     - dbt_utils.expression_is_true:
-        expression: status = 'finished'
+        expression: status IN ('finished', 'awarded')
         where: CAST(match_at AS DATE) < last_updated_at - INTERVAL 24 HOURS # -- all matches up to 24 hours before the last extraction must be "finished". Matches in the last 24 hours, depending on when they are scheduled, may be ongoing at the time of extraction.
     - dbt_utils.expression_is_true:
         expression: matchday_number > 0

--- a/sports-db-project/sports_db_dbt/models/staging/stg_football_data__players.sql
+++ b/sports-db-project/sports_db_dbt/models/staging/stg_football_data__players.sql
@@ -9,7 +9,15 @@ SELECT
 	CAST(name AS VARCHAR) AS name,
 	CAST(firstName AS VARCHAR) AS first_name,
 	CAST(lastName AS VARCHAR) AS last_name,
-	CAST(dateOfBirth AS DATE) AS date_of_birth,
+	CASE 
+		WHEN id = 191106 THEN CAST('2005-01-04' AS DATE)
+		WHEN id = 191127 THEN CAST('1998-05-12' AS DATE)
+		WHEN id = 263454 THEN CAST('2007-05-09' AS DATE)
+		WHEN id = 170381 THEN CAST('1993-02-19' AS DATE)
+		WHEN id = 160790 THEN CAST('2004-04-06' AS DATE)
+		WHEN id = 191811 THEN {{ var('default_birth_date') }} -- Unknown so we set a default date
+		ELSE CAST(dateOfBirth AS DATE) 
+	END AS date_of_birth,
 	CAST(nationality AS VARCHAR) AS nationality,
 	CAST(section AS VARCHAR) AS section,
 	CAST(position AS VARCHAR) AS position,

--- a/sports-db-project/sports_db_dbt/models/staging/stg_football_data__players.yml
+++ b/sports-db-project/sports_db_dbt/models/staging/stg_football_data__players.yml
@@ -10,22 +10,27 @@ models:
         data_tests:
           - unique
           - not_null
+
       - name: name
         description: Full name of the player
         data_type: VARCHAR
         data_tests:
           - not_null
+
       - name: first_name
         description: First name of the player
         data_type: VARCHAR
+
       - name: last_name
         description: Last name of the player
         data_type: VARCHAR
+
       - name: date_of_birth
         description: Player's date of birth
         data_type: DATE
         data_tests:
           - not_null
+
       - name: nationality
         description: Player's nationality
         data_type: VARCHAR
@@ -34,6 +39,7 @@ models:
           - relationships: 
               to: ref('stg_football_data__areas')
               field: country_name
+
       - name: section
         description: Section or category the player belongs to
         data_type: VARCHAR
@@ -41,6 +47,7 @@ models:
           - not_null
           - accepted_values:
               values: '{{ var("football_positions") }}'  
+      
       - name: position
         description: Player's position on the field
         data_type: VARCHAR
@@ -48,6 +55,7 @@ models:
           - not_null
           - accepted_values:
               values: '{{ var("football_positions") }}'  
+      
       - name: player_number
         description: Player's jersey number
         data_type: INTEGER
@@ -55,6 +63,7 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               max_value: 100
+      
       - name: current_team_id
         description: Foreign key to the team the player currently belongs to
         data_type: VARCHAR
@@ -63,12 +72,15 @@ models:
           - relationships:
               to: ref('stg_football_data__teams')
               field: team_id
+      
       - name: contract_start_month
         description: Month when the player's contract started
         data_type: DATE
+      
       - name: contract_end_month
         description: Month when the player's contract ends
         data_type: DATE
+      
       - name: last_updated_at
         description: Timestamp of when the record was last updated
         data_type: DATETIME


### PR DESCRIPTION
❌ Bug : The matches with `status` = 'awarded' were filtered out of the standings computation, returning a wrong number of pts for some teams.
✅ Solution : This status is given to a match when the result was decided by an external decision. For instance, as a punishment for dangerous fans' behvior. It is therefore now included in the standings computation.